### PR TITLE
crash applying ds change fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 *.pyc
 *.DS_Store
 *.zip
+help/
+i18n/
+scripts/
+test/
+.idea/

--- a/layer_board.py
+++ b/layer_board.py
@@ -602,7 +602,8 @@ class LayerBoard:
 
     def setDataSource(self,layer,newSourceUri):
         #method to apply a new datasource to a vector Layer
-        newUri,newDatasourceType = self.splitSource(newSourceUri)
+        newDS, newUri = self.splitSource(newSourceUri)
+        newDatasourceType = newDS or layer.dataProvider().name()
         # read layer definition
         XMLDocument = QDomDocument("style")
         XMLMapLayers = QDomElement()


### PR DESCRIPTION
Hi Michel,
there was a bug in the latest commit that causes qgis crashes due to inverted variables assignment.
Here is the fix.
Bye.
Enrico Ferreguti.