### PR TITLE
[BUGFIX] layer's minScale can be float infinity

### DIFF
--- a/layer_board.py
+++ b/layer_board.py
@@ -478,7 +478,10 @@ class LayerBoard:
             return int( layer.maximumScale() )
 
         elif prop == 'minScale':
-            return int( layer.minimumScale() )
+            try:
+                return int( layer.minimumScale() )
+            except:
+                return 0
 
         # vector
         elif prop == 'labelsEnabled':


### PR DESCRIPTION
Fixed #17 Uncaught OverflowError: cannot convert float infinity to integer